### PR TITLE
Allow disabling validation in update

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,8 @@ var Tweet = dynogels.define('Tweet', {
 #### Data Validation
 Dynogels automatically validates the model against the schema before attempting to save it, but you can also call the `validate` method to validate an object before saving it. This can be helpful for a handler to validate input.
 
+As an option, you can disable validation with the `validate: false` option when calling `Table.update(...)`.  On partial updates, it is often impossible to safely validate part of a model (since there might be validation dependencies on other, unprovided properties).
+
 ```js
 var Tweet = dynogels.define('Tweet', {
   hashKey : 'TweetID',

--- a/lib/table.js
+++ b/lib/table.js
@@ -299,12 +299,14 @@ Table.prototype.update = function (item, options, callback) {
   callback = callback || _.noop;
   options = options || {};
 
-  const schemaValidation = internals.validateItemFragment(item, self.schema);
-  if (schemaValidation.error) {
-    return callback(_.assign(new Error(`Schema validation error while updating item in table ${self.tableName()}: ${JSON.stringify(schemaValidation.error)}`), {
-      name: 'DynogelsUpdateError',
-      detail: schemaValidation.error
-    }));
+  if (options.validate !== false) {
+    const schemaValidation = internals.validateItemFragment(item, self.schema);
+    if (schemaValidation.error) {
+      return callback(_.assign(new Error(`Schema validation error while updating item in table ${self.tableName()}: ${JSON.stringify(schemaValidation.error)}`), {
+        name: 'DynogelsUpdateError',
+        detail: schemaValidation.error
+      }));
+    }
   }
 
   const start = (callback) => {


### PR DESCRIPTION
Allow disabling schema validation on update with `table.update(data, { validate: false}, callback)`.  By default, dynogels will continue to perform partial schema validation on update, which may not be feasible with schemas whose fields' validity is dependent on the values of other, unspecified fields.